### PR TITLE
Add missing permissions for iOS

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Francis required to access the local network to looking for services.</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_dns-sd._udp</string>
+	</array>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# Context

iOS 14 add a new requirement in order to browse via bonjour on the local network. In order to conform to that we need to define two keys in Info.plist:
- "Privacy - Local Network Usage Description" 
- "Bonjour services"

# Fix issue
Should close #2 

# Reference
https://developer.apple.com/videos/play/wwdc2020/10110/